### PR TITLE
Fixed location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This action supports both the `Deploy webhook URL` found in the site repository 
 **Required** Deploy webhook URL.
 _It is advised to use Github secrets to keep your webhook URL private._
 
-The webhook url can be found in your sites Settings tab.
+The webhook url can be found in your sites Repository tab.
 
 ### API deployment
 


### PR DESCRIPTION
Location of webhook url incorrect - updated to the correct tab of Repository.