### PR TITLE
Rename master to main

### DIFF
--- a/examples/deploy-if-message-contains.yml
+++ b/examples/deploy-if-message-contains.yml
@@ -3,7 +3,7 @@ name: 'Deploy if message contains'
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ploi-deploy:

--- a/examples/deploy-on-push.yml
+++ b/examples/deploy-on-push.yml
@@ -3,7 +3,7 @@ name: 'Deploy on push'
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ploi-deploy:

--- a/examples/deploy-on-tests-success.yml
+++ b/examples/deploy-on-tests-success.yml
@@ -3,7 +3,7 @@ name: 'Deploy on tests success'
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ploi-deploy:


### PR DESCRIPTION
Sorry, forgot to fix this in the examples as well. Should be consistent now.